### PR TITLE
fix for windows deployments when copying .sh files into linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+*.sh text eol=lf
+*.conf text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 * text=auto
 *.sh text eol=lf
-*.conf text eol=lf


### PR DESCRIPTION
Docker on Windows, and mounting the application's code through a volume, copying the rails-service.sh bash script it adds an extra character to the end.

Adding the .gitattributes file with the config to control line-ending normalisation in Git. 

Here's a breakdown of what each line does:
* text=auto - Automatically detects text files and normalizes line endings based on the user's OS.
*.sh text eol=lf - Forces files to always use LF line endings, both in the repository and in the working directory.